### PR TITLE
Performance improvements

### DIFF
--- a/src/Algorithms/base.js
+++ b/src/Algorithms/base.js
@@ -1,0 +1,9 @@
+export const neighbours = (coord, sizeX, sizeY) => {
+    const [x, y] = coord;
+
+    const neighboursRelative = [[1, 1], [0, 1], [1, 0], [1, -1], [0, -1], [-1, 0]];
+
+    return neighboursRelative.map((coord) => {
+        return [coord[0] + x, coord[1] + y]
+    })
+}

--- a/src/Algorithms/base.test.js
+++ b/src/Algorithms/base.test.js
@@ -1,0 +1,5 @@
+import { neighbours } from "./base";
+
+test("neighbours returns", () => {
+    console.log(neighbours([0, 1], 10, 10));
+})

--- a/src/Canvas/canvas.jsx
+++ b/src/Canvas/canvas.jsx
@@ -1,28 +1,30 @@
 import React, { useRef, useEffect, useState } from "react";
 
 const Canvas = (props) => {
-    const { Component, ...other } = props;
+  const { Component, ...other } = props;
 
-    const ref = useRef(null);
-    const [windowSize, setWindowSize] = useState({height: 0, width: 0});
+  const ref = useRef(null);
+  const [windowSize, setWindowSize] = useState({ height: 0, width: 0 });
 
-    useEffect(() => {
-        setWindowSize({
-            height: ref.current.offsetHeight,
-            width: ref.current.offsetWidth
-        })
-    }, []);
+  useEffect(() => {
+    setWindowSize({
+      height: ref.current.offsetHeight,
+      width: ref.current.offsetWidth,
+    });
+  }, []);
 
-    const canvasStyle = {
-        overflow: "hidden",
-        height: "100vh",
-        width: "100vw",
-        backgroundColor: "#dddddd"
-    }
+  const canvasStyle = {
+    overflow: "hidden",
+    height: "100vh",
+    width: "100vw",
+    backgroundColor: "#dddddd",
+  };
 
-    return (<div ref={ref} style={canvasStyle}>
-        <Component {...{windowSize, ...other}} />
-    </div>);
-}
+  return (
+    <div ref={ref} style={canvasStyle}>
+      <Component {...{ windowSize, ...other }} />
+    </div>
+  );
+};
 
 export default Canvas;

--- a/src/Canvas/canvas.jsx
+++ b/src/Canvas/canvas.jsx
@@ -1,30 +1,28 @@
 import React, { useRef, useEffect, useState } from "react";
 
 const Canvas = (props) => {
-  const { Component, ...other } = props;
+    const { Component, ...other } = props;
 
-  const ref = useRef(null);
-  const [windowSize, setWindowSize] = useState({ height: 0, width: 0 });
+    const ref = useRef(null);
+    const [windowSize, setWindowSize] = useState({height: 0, width: 0});
 
-  useEffect(() => {
-    setWindowSize({
-      height: ref.current.offsetHeight,
-      width: ref.current.offsetWidth,
-    });
-  }, []);
+    useEffect(() => {
+        setWindowSize({
+            height: ref.current.offsetHeight,
+            width: ref.current.offsetWidth
+        })
+    }, []);
 
-  const canvasStyle = {
-    overflow: "hidden",
-    height: "100vh",
-    width: "100vw",
-    backgroundColor: "#dddddd",
-  };
+    const canvasStyle = {
+        overflow: "hidden",
+        height: "100vh",
+        width: "100vw",
+        backgroundColor: "#dddddd"
+    }
 
-  return (
-    <div ref={ref} style={canvasStyle}>
-      <Component {...{ windowSize, ...other }} />
-    </div>
-  );
-};
+    return (<div ref={ref} style={canvasStyle}>
+        <Component {...{windowSize, ...other}} />
+    </div>);
+}
 
 export default Canvas;

--- a/src/Hexagon/hexagon.jsx
+++ b/src/Hexagon/hexagon.jsx
@@ -71,7 +71,7 @@ const typeToStyling = (type) => {
 }
 
 const Hexagon = (props) => {
-    const [type, setType] = useState('space');
+    const [type, setType] = useState(props.type ?? 'space');
 
     const handleChange = () => {
         const newType = props.selected;

--- a/src/Hexagon/hexagon.jsx
+++ b/src/Hexagon/hexagon.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import styled from "styled-components";
 
 // TODO: Cannot find a way to set multiple properties to the same value,
@@ -78,24 +78,22 @@ const typeToStyling = (type) => {
 class Hexagon extends React.Component {
   constructor(props) {
     super(props);
-    this.type = props.type ?? "space";
+    this.state = {
+      type: props.type,
+      selected: props.selected,
+      mouseDown: props.mouseDown,
+    };
+
+    this.css = props.css;
   }
 
-  shouldComponentUpdate(nextProps) {
-    return this.type !== nextProps.type;
+  shouldComponentUpdate(nextProps, nextState) {
+    return nextState.type !== this.state.type;
   }
 
   handleChange = (event) => {
     if (event.button === 0) {
-      const newType = this.props.selected;
-      let newHexagonState = { ...this.props.hexagonStates };
-      if (newType === "goal" || newType === "start") {
-        newHexagonState[newType] = [this.props.coord];
-      } else {
-        newHexagonState[newType].push(this.props.coord);
-      }
-      this.props.setHexagonStates(newHexagonState);
-      this.setState({ type: newType });
+      this.setState({ type: this.props.selected });
     }
   };
 
@@ -106,11 +104,12 @@ class Hexagon extends React.Component {
   };
 
   render() {
-    const backgroundColor = typeToStyling(this.props.type);
+    console.log("rendering");
+    const backgroundColor = typeToStyling(this.state.type);
 
     return (
       <StyledHexagon
-        {...{ ...this.props, backgroundColor }}
+        {...{ ...this.css, backgroundColor }}
         style={this.props.style}
         onClick={this.handleChange}
         onMouseOver={this.handleHover}
@@ -119,40 +118,5 @@ class Hexagon extends React.Component {
     );
   }
 }
-
-// const Hexagon = (props) => {
-//     const [type, setType] = useState(props.type ?? 'space');
-
-//     // Only one hexagon can be a start/end point, so when a new hexagon
-//     // converts to that then new props are passed into this
-//     if (props.type !== type) {
-//         setType(props.type);
-//     }
-
-//     const handleChange = (event) => {
-//         if (event.button === 0) {
-//             const newType = props.selected;
-//             let newHexagonState = {...props.hexagonStates};
-//             if (newType === 'goal' || newType === 'start') {
-//                 newHexagonState[newType] = [props.coord];
-//             } else {
-//                 newHexagonState[newType].push(props.coord);
-//             }
-//             props.setHexagonStates(newHexagonState);
-//             setType(newType);
-//         }
-//     }
-
-//     const handleHover = (event) => {
-//         if (props.mouseDown) {
-//             handleChange(event);
-//         }
-//     }
-
-//     const backgroundColor = typeToStyling(type);
-
-//     return <StyledHexagon {...{...props, backgroundColor}} style={props.style}
-//     onClick={handleChange} onMouseOver={handleHover} onMouseDown={handleChange} />;
-// }
 
 export default Hexagon;

--- a/src/Hexagon/hexagon.jsx
+++ b/src/Hexagon/hexagon.jsx
@@ -94,11 +94,13 @@ class Hexagon extends React.Component {
   }
 
   shouldComponentUpdate(nextProps, nextState) {
+    if (nextProps.type !== this.props.type) {
+      this.setState({ previousState: nextProps.type });
+      return true;
+    } else {
+      return false;
+    }
     return nextProps.type !== this.props.type;
-  }
-
-  componentDidUpdate(prevProps, prevState) {
-    this.setState({ previousState: prevProps.type });
   }
 
   removeOldState(oldType, newHexagonStates) {
@@ -126,15 +128,14 @@ class Hexagon extends React.Component {
   }
 
   handleChange = (event, oldType) => {
-    console.log(oldType, this.props.coord);
     if (event.button === 0) {
       const newType = this.props.selected;
 
       if (newType !== this.state.previousState) {
         let newHexagonStates = { ...this.props.hexagonStates };
 
-        newHexagonStates = this.addNewState(newType, newHexagonStates);
         newHexagonStates = this.removeOldState(oldType, newHexagonStates);
+        newHexagonStates = this.addNewState(newType, newHexagonStates);
 
         this.props.setHexagonStates(newHexagonStates);
       }
@@ -148,8 +149,8 @@ class Hexagon extends React.Component {
   };
 
   render() {
-    const backgroundColor = typeToStyling(this.props.type);
-    const previous = this.state.previousState;
+    const previous = this.props.type;
+    const backgroundColor = typeToStyling(previous);
 
     return (
       <StyledHexagon

--- a/src/Hexagon/hexagon.jsx
+++ b/src/Hexagon/hexagon.jsx
@@ -79,21 +79,30 @@ const Hexagon = (props) => {
         setType(props.type);
     }
 
-    const handleChange = () => {
-        const newType = props.selected;
-        let newHexagonState = {...props.hexagonStates};
-        if (newType === 'goal' || newType === 'start') {
-            newHexagonState[newType] = [props.coord];
-        } else {
-            newHexagonState[newType].push(props.coord);
+    const handleChange = (event) => {
+        if (event.button === 0) {
+            const newType = props.selected;
+            let newHexagonState = {...props.hexagonStates};
+            if (newType === 'goal' || newType === 'start') {
+                newHexagonState[newType] = [props.coord];
+            } else {
+                newHexagonState[newType].push(props.coord);
+            }
+            props.setHexagonStates(newHexagonState);
+            setType(newType);
         }
-        props.setHexagonStates(newHexagonState);
-        setType(newType);
+    }
+
+    const handleHover = (event) => {
+        if (props.mouseDown) {
+            handleChange(event);
+        }
     }
 
     const backgroundColor = typeToStyling(type);
 
-    return <StyledHexagon {...{...props, backgroundColor}} style={props.style} onClick={handleChange} />;
+    return <StyledHexagon {...{...props, backgroundColor}} style={props.style}
+    onClick={handleChange} onMouseOver={handleHover} onMouseDown={handleChange} />;
 }
 
 export default Hexagon;

--- a/src/Hexagon/hexagon.jsx
+++ b/src/Hexagon/hexagon.jsx
@@ -5,6 +5,9 @@ import { arrayEquals } from "../Utilities/utilities";
 // TODO: Cannot find a way to set multiple properties to the same value,
 // would be useful for setting border-left and border-right at the same time,
 // have tried using , like with &:before &:after but that doesn't work
+/**
+ * A CSS hexagon, with configurable size, colours, and border
+ */
 const StyledHexagon = styled.div`
   position: absolute;
   width: ${(props) => `${props.middleWidth}px`};
@@ -36,13 +39,17 @@ const StyledHexagon = styled.div`
   }
 `;
 
+// Used in the CSS hexagon above
 const borderStyle = (borderWidth) => `solid ${borderWidth}px #333333`;
 
-export const hexagonStylingProps = ({
-  width,
-  borderWidth,
-  backgroundColor,
-}) => {
+/**
+ * Returns an object containing all parameters that physically specify a hexagon
+ * @param {float} width: the distance between two opposite sides of the hexagon, not
+ * including the border width
+ * @param {float} borderWidth: the width of the border, from the outer of the hexagon
+ * to the outer of the border
+ */
+export const hexagonStylingProps = ({ width, borderWidth }) => {
   return {
     middleWidth: width,
     middleHeight: (Math.sqrt(3) / 3) * width,
@@ -52,10 +59,13 @@ export const hexagonStylingProps = ({
     middleBorderWidth: borderWidth,
     left: -borderWidth - width / (Math.sqrt(2) * 2) + width / 2,
     topBot: -width / (Math.sqrt(2) * 2),
-    backgroundColor,
   };
 };
 
+/**
+ * Converts the type of a hexagon into the colour it's background should be
+ * @param type: the state of the hexagon, currently 'space', 'wall', 'goal', or 'start'
+ */
 const typeToStyling = (type) => {
   let backgroundColor = "#64C7CC";
   switch (type) {
@@ -76,36 +86,50 @@ const typeToStyling = (type) => {
   return backgroundColor;
 };
 
-const limitedState = {
-  wall: false,
-  goal: true,
-  start: true,
-};
-
+/**
+ * A general hexagon class, used to build up the hexagon grid.
+ * The logic behind it is as follows:
+ * - The type the hexagon should be (e.g. 'wall', 'start' etc) is passed in on props and the hexagon renders
+ * - When the hexagon is clicked OR dragged over with a new type selected in the toolbar, the updated state is sent
+ * to the overall store for the grid
+ * - This new grid state is then passed down to each hexagon, NOTE: some states are limited
+ * (e.g. can only be one 'start' state), so if a new 'start' state is created the old one is removed
+ * - When each hexagon receives it's new type (according to the grid store), it updates only if it's current type
+ * doesn't match the new one
+ */
 class Hexagon extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      previousState: props.type,
-      mouseDown: props.mouseDown,
-    };
+  /**
+   * A mapping from state types to whether that state is limited in it's numbers or not
+   * there can only be one goal and one start point, but many walls
+   * NOTE: 'space' is not mapped here as it should be checked seperately and space locations
+   * are not stored, a grid can be
+   * fully specified using it's dimensions, and the location of the remaining hexagon types
+   */
+  limitedState = {
+    wall: false,
+    goal: true,
+    start: true,
+  };
 
-    this.css = props.css;
-  }
-
-  shouldComponentUpdate(nextProps, nextState) {
-    if (nextProps.type !== this.props.type) {
-      this.setState({ previousState: nextProps.type });
-      return true;
-    } else {
-      return false;
-    }
+  /**
+   * Decides whether the component needs to rerender, based on the set of props that have just
+   * been passed in
+   * @param {object} nextProps: the new properties passed into the hexagon
+   */
+  shouldComponentUpdate(nextProps) {
     return nextProps.type !== this.props.type;
   }
 
+  /**
+   * Updates the hexagonStates object that specifies all the states of the hexagonGrid, by removing
+   * the old state of this hexagon from it
+   * @param {string} oldType: 'space' | 'wall' | 'goal' | 'start'
+   * @param {object} newHexagonStates: a copy of the hexagonStates object to modify
+   * @returns newHexagonStates: with the old state of this hexagon removed
+   */
   removeOldState(oldType, newHexagonStates) {
     if (oldType !== "space") {
-      if (limitedState[oldType]) {
+      if (this.limitedState[oldType]) {
         newHexagonStates[oldType] = [];
       } else {
         newHexagonStates[oldType] = newHexagonStates[oldType].filter(
@@ -116,9 +140,16 @@ class Hexagon extends React.Component {
     return newHexagonStates;
   }
 
+  /**
+   * Updates the hexagonStates object that specifies all the states of the hexagonGrid, by adding the
+   * new state of this hexagon to it
+   * @param {string} newType: 'space' | 'wall' | 'goal' | 'start'
+   * @param {object} newHexagonStates: a copy of the hexagonStates object to modify
+   * @returns newHexagonStates: with the new state of this hexagon added to it
+   */
   addNewState(newType, newHexagonStates) {
     if (newType !== "space") {
-      if (limitedState[newType]) {
+      if (this.limitedState[newType]) {
         newHexagonStates[newType] = [this.props.coord];
       } else {
         newHexagonStates[newType].push(this.props.coord);
@@ -127,11 +158,17 @@ class Hexagon extends React.Component {
     return newHexagonStates;
   }
 
+  /**
+   * Utilises the addNewState and removeOldState methods to update the hexagonGridState,
+   * which subsequently gets passed down as a new prop
+   * @param {object} event: event object from e.g. a click
+   * @param {string} oldType: 'space' | 'wall' | 'goal' | 'start'
+   */
   handleChange = (event, oldType) => {
     if (event.button === 0) {
       const newType = this.props.selected;
 
-      if (newType !== this.state.previousState) {
+      if (newType !== oldType) {
         let newHexagonStates = { ...this.props.hexagonStates };
 
         newHexagonStates = this.removeOldState(oldType, newHexagonStates);
@@ -142,6 +179,11 @@ class Hexagon extends React.Component {
     }
   };
 
+  /**
+   * Triggered when the mouse hovers over the top of the hexagon
+   * @param {object} event: onMouseOver event
+   * @param {string} oldType: 'space' | 'wall' | 'goal' | 'start'
+   */
   handleHover = (event, oldType) => {
     if (this.props.mouseDown) {
       this.handleChange(event, oldType);
@@ -149,16 +191,17 @@ class Hexagon extends React.Component {
   };
 
   render() {
-    const previous = this.props.type;
-    const backgroundColor = typeToStyling(previous);
+    const type = this.props.type;
+    const backgroundColor = typeToStyling(type);
 
+    // NOTE: Type is stored in the functions instead of on this.state
     return (
       <StyledHexagon
-        {...{ ...this.css, backgroundColor }}
+        {...{ ...this.props.css, backgroundColor }}
         style={this.props.style}
-        onClick={(event) => this.handleChange(event, previous)}
-        onMouseOver={(event) => this.handleHover(event, previous)}
-        onMouseDown={(event) => this.handleChange(event, previous)}
+        onClick={(event) => this.handleChange(event, type)}
+        onMouseOver={(event) => this.handleHover(event, type)}
+        onMouseDown={(event) => this.handleChange(event, type)}
       />
     );
   }

--- a/src/Hexagon/hexagon.jsx
+++ b/src/Hexagon/hexagon.jsx
@@ -5,104 +5,161 @@ import styled from "styled-components";
 // would be useful for setting border-left and border-right at the same time,
 // have tried using , like with &:before &:after but that doesn't work
 const StyledHexagon = styled.div`
+  position: absolute;
+  width: ${(props) => `${props.middleWidth}px`};
+  height: ${(props) => `${props.middleHeight}px`};
+  background-color: ${(props) => props.backgroundColor};
+  margin: ${(props) => `${props.margin}px`};
+  border-left: ${(props) => borderStyle(props.middleBorderWidth)};
+  border-right: ${(props) => borderStyle(props.middleBorderWidth)};
+  &:before,
+  &:after {
+    content: "";
     position: absolute;
-    width: ${props => `${props.middleWidth}px`};
-    height: ${props => `${props.middleHeight}px`};
-    background-color: ${props => props.backgroundColor};
-    margin: ${props => `${props.margin}px`};
-    border-left: ${props => borderStyle(props.middleBorderWidth)};
-    border-right: ${props => borderStyle(props.middleBorderWidth)};
-    &:before, &:after {
-        content: "";
-        position: absolute;
-        z-index: 1;
-        width: ${props => `${props.topBotDiameter}px`};
-        height: ${props => `${props.topBotDiameter}px`};
-        transform: scaleY(0.5774) rotate(-45deg);
-        background-color: inherit;
-        left: ${props => `${props.left}px`};
-    }
-    &:before {
-        top: ${props => `${props.topBot}px`};
-        border-top: ${props => borderStyle(props.topBotBorderWidth)};
-        border-right: ${props => borderStyle(props.topBotBorderWidth)};
-    }
-    &:after {
-        bottom: ${props => `${props.topBot}px`};
-        border-bottom: ${props => borderStyle(props.topBotBorderWidth)};
-        border-left: ${props => borderStyle(props.topBotBorderWidth)};
-    }
+    z-index: 1;
+    width: ${(props) => `${props.topBotDiameter}px`};
+    height: ${(props) => `${props.topBotDiameter}px`};
+    transform: scaleY(0.5774) rotate(-45deg);
+    background-color: inherit;
+    left: ${(props) => `${props.left}px`};
+  }
+  &:before {
+    top: ${(props) => `${props.topBot}px`};
+    border-top: ${(props) => borderStyle(props.topBotBorderWidth)};
+    border-right: ${(props) => borderStyle(props.topBotBorderWidth)};
+  }
+  &:after {
+    bottom: ${(props) => `${props.topBot}px`};
+    border-bottom: ${(props) => borderStyle(props.topBotBorderWidth)};
+    border-left: ${(props) => borderStyle(props.topBotBorderWidth)};
+  }
 `;
 
-const borderStyle = (borderWidth) => `solid ${borderWidth}px #333333`
+const borderStyle = (borderWidth) => `solid ${borderWidth}px #333333`;
 
-export const hexagonStylingProps = ({ width, borderWidth, backgroundColor }) => {
-    return {
-        middleWidth: width,
-        middleHeight: (Math.sqrt(3) / 3) * width,
-        topBotDiameter: width / Math.sqrt(2),
-        margin: width * Math.sqrt(3) / 6,
-        topBotBorderWidth: borderWidth * Math.sqrt(2),
-        middleBorderWidth: borderWidth,
-        left: - borderWidth - width / (Math.sqrt(2) * 2) + width / 2,
-        topBot: -width / (Math.sqrt(2) * 2),
-        backgroundColor
-    }
-}
+export const hexagonStylingProps = ({
+  width,
+  borderWidth,
+  backgroundColor,
+}) => {
+  return {
+    middleWidth: width,
+    middleHeight: (Math.sqrt(3) / 3) * width,
+    topBotDiameter: width / Math.sqrt(2),
+    margin: (width * Math.sqrt(3)) / 6,
+    topBotBorderWidth: borderWidth * Math.sqrt(2),
+    middleBorderWidth: borderWidth,
+    left: -borderWidth - width / (Math.sqrt(2) * 2) + width / 2,
+    topBot: -width / (Math.sqrt(2) * 2),
+    backgroundColor,
+  };
+};
 
 const typeToStyling = (type) => {
-    let backgroundColor = "#64C7CC"
-    switch (type) {
-        case 'space':
-            break;
-        case 'wall':
-            backgroundColor = "#000000";
-            break;
-        case 'goal':
-            backgroundColor = "#00ff00";
-            break;
-        case 'start':
-            backgroundColor = "#ff0000";
-            break;
-        default:
-            break;
+  let backgroundColor = "#64C7CC";
+  switch (type) {
+    case "space":
+      break;
+    case "wall":
+      backgroundColor = "#000000";
+      break;
+    case "goal":
+      backgroundColor = "#00ff00";
+      break;
+    case "start":
+      backgroundColor = "#ff0000";
+      break;
+    default:
+      break;
+  }
+  return backgroundColor;
+};
+
+// TODO: This component is still updating all the time for some reason, also getting update depth exceeded
+class Hexagon extends React.Component {
+  constructor(props) {
+    super(props);
+    this.type = props.type ?? "space";
+  }
+
+  shouldComponentUpdate(nextProps) {
+    console.log(this.type, nextProps.type);
+    return this.type !== nextProps.type;
+  }
+
+  handleChange = (event) => {
+    if (event.button === 0) {
+      const newType = this.props.selected;
+      let newHexagonState = { ...this.props.hexagonStates };
+      if (newType === "goal" || newType === "start") {
+        newHexagonState[newType] = [this.props.coord];
+      } else {
+        newHexagonState[newType].push(this.props.coord);
+      }
+      console.log("new type", newType);
+      this.props.setHexagonStates(newHexagonState);
+      this.setState({ type: newType });
+      console.log("new state", this.type);
     }
-    return backgroundColor;
+  };
+
+  handleHover = (event) => {
+    if (this.props.mouseDown) {
+      this.handleChange(event);
+    }
+  };
+
+  render() {
+    console.log(this.props);
+    this.setState({ type: this.props.type });
+
+    const backgroundColor = typeToStyling(this.type);
+
+    return (
+      <StyledHexagon
+        {...{ ...this.props, backgroundColor }}
+        style={this.props.style}
+        onClick={this.handleChange}
+        onMouseOver={this.handleHover}
+        onMouseDown={this.handleChange}
+      />
+    );
+  }
 }
 
-const Hexagon = (props) => {
-    const [type, setType] = useState(props.type ?? 'space');
+// const Hexagon = (props) => {
+//     const [type, setType] = useState(props.type ?? 'space');
 
-    // Only one hexagon can be a start/end point, so when a new hexagon
-    // converts to that then new props are passed into this
-    if (props.type !== type) {
-        setType(props.type);
-    }
+//     // Only one hexagon can be a start/end point, so when a new hexagon
+//     // converts to that then new props are passed into this
+//     if (props.type !== type) {
+//         setType(props.type);
+//     }
 
-    const handleChange = (event) => {
-        if (event.button === 0) {
-            const newType = props.selected;
-            let newHexagonState = {...props.hexagonStates};
-            if (newType === 'goal' || newType === 'start') {
-                newHexagonState[newType] = [props.coord];
-            } else {
-                newHexagonState[newType].push(props.coord);
-            }
-            props.setHexagonStates(newHexagonState);
-            setType(newType);
-        }
-    }
+//     const handleChange = (event) => {
+//         if (event.button === 0) {
+//             const newType = props.selected;
+//             let newHexagonState = {...props.hexagonStates};
+//             if (newType === 'goal' || newType === 'start') {
+//                 newHexagonState[newType] = [props.coord];
+//             } else {
+//                 newHexagonState[newType].push(props.coord);
+//             }
+//             props.setHexagonStates(newHexagonState);
+//             setType(newType);
+//         }
+//     }
 
-    const handleHover = (event) => {
-        if (props.mouseDown) {
-            handleChange(event);
-        }
-    }
+//     const handleHover = (event) => {
+//         if (props.mouseDown) {
+//             handleChange(event);
+//         }
+//     }
 
-    const backgroundColor = typeToStyling(type);
+//     const backgroundColor = typeToStyling(type);
 
-    return <StyledHexagon {...{...props, backgroundColor}} style={props.style}
-    onClick={handleChange} onMouseOver={handleHover} onMouseDown={handleChange} />;
-}
+//     return <StyledHexagon {...{...props, backgroundColor}} style={props.style}
+//     onClick={handleChange} onMouseOver={handleHover} onMouseDown={handleChange} />;
+// }
 
 export default Hexagon;

--- a/src/Hexagon/hexagon.jsx
+++ b/src/Hexagon/hexagon.jsx
@@ -75,7 +75,6 @@ const typeToStyling = (type) => {
   return backgroundColor;
 };
 
-// TODO: This component is still updating all the time for some reason, also getting update depth exceeded
 class Hexagon extends React.Component {
   constructor(props) {
     super(props);
@@ -83,7 +82,6 @@ class Hexagon extends React.Component {
   }
 
   shouldComponentUpdate(nextProps) {
-    console.log(this.type, nextProps.type);
     return this.type !== nextProps.type;
   }
 
@@ -96,10 +94,8 @@ class Hexagon extends React.Component {
       } else {
         newHexagonState[newType].push(this.props.coord);
       }
-      console.log("new type", newType);
       this.props.setHexagonStates(newHexagonState);
       this.setState({ type: newType });
-      console.log("new state", this.type);
     }
   };
 
@@ -110,10 +106,7 @@ class Hexagon extends React.Component {
   };
 
   render() {
-    console.log(this.props);
-    this.setState({ type: this.props.type });
-
-    const backgroundColor = typeToStyling(this.type);
+    const backgroundColor = typeToStyling(this.props.type);
 
     return (
       <StyledHexagon

--- a/src/Hexagon/hexagon.jsx
+++ b/src/Hexagon/hexagon.jsx
@@ -73,10 +73,20 @@ const typeToStyling = (type) => {
 const Hexagon = (props) => {
     const [type, setType] = useState(props.type ?? 'space');
 
+    // Only one hexagon can be a start/end point, so when a new hexagon
+    // converts to that then new props are passed into this
+    if (props.type !== type) {
+        setType(props.type);
+    }
+
     const handleChange = () => {
         const newType = props.selected;
         let newHexagonState = {...props.hexagonStates};
-        newHexagonState[newType].push(props.coord);
+        if (newType === 'goal' || newType === 'start') {
+            newHexagonState[newType] = [props.coord];
+        } else {
+            newHexagonState[newType].push(props.coord);
+        }
         props.setHexagonStates(newHexagonState);
         setType(newType);
     }

--- a/src/HexagonGrid/hexagonGrid.jsx
+++ b/src/HexagonGrid/hexagonGrid.jsx
@@ -3,7 +3,7 @@ import Hexagon, { hexagonStylingProps } from "../Hexagon/hexagon";
 
 const HexagonGrid = (props) => {
     const { width = 50, borderWidth = 5, spacing = 5,
-		backgroundColor = "#64C7CC", ...other } = props
+		backgroundColor = "#64C7CC", ...other } = props;
 		
     const createGrid = (windowSize, width, spacing, borderWidth) => {
         if (windowSize.height !== 0 && windowSize.width !== 0) {
@@ -23,7 +23,7 @@ const HexagonGrid = (props) => {
                 }
             }
             
-            return { coords, spaceX, spaceY }
+            return { coords, spaceX, spaceY, sizeX, sizeY }
         }
     }
 
@@ -37,13 +37,30 @@ const HexagonGrid = (props) => {
         }
     
         return { pixelsX, pixelsY }
-    }
+		}
+		
+		const hexagonStartingStates = (gridProps, hexagonStates) => {
+			if (gridProps) {
+				const hexagonStartingStates = new Array(gridProps.coords.length).fill('space');
+				const { sizeY } = gridProps;
+		
+				Object.entries(props.hexagonStates).forEach((row) => {
+					const key = row[0];
+					row[1].forEach((coord) => {
+						hexagonStartingStates[coord[0] * sizeY + coord[1]] = key;
+					})
+				})
+
+				return hexagonStartingStates;
+			}
+		}
 
     const gridProps = createGrid(props.windowSize, width, spacing, borderWidth)
-    const hexagonProps = hexagonStylingProps({ width, borderWidth, backgroundColor });
+		const hexagonProps = hexagonStylingProps({ width, borderWidth, backgroundColor });
+		const hexagonStates = hexagonStartingStates(gridProps, props.hexagonStates);
 
     return (<div>
-        {gridProps && gridProps.coords.map(coord => {
+        {gridProps && gridProps.coords.map((coord, i) => {
             const [x, y] = coord;
 
             const transform = coordToPixels(x, y, spacing, width);
@@ -53,8 +70,12 @@ const HexagonGrid = (props) => {
             const style = {
                 transform: `translate(${transform.pixelsX}px, ${transform.pixelsY}px)`
 						}
+
+						const type = {
+							type: hexagonStates[i]
+						}
 						
-            return <Hexagon key={`${x}:${y}`} style={style} {...{...hexagonProps, coord, ...other}} />
+            return <Hexagon key={`${x}:${y}`} style={style} {...{...hexagonProps, ...type, coord, ...other}} />
         })}
     </div>)
 }

--- a/src/HexagonGrid/hexagonGrid.jsx
+++ b/src/HexagonGrid/hexagonGrid.jsx
@@ -3,10 +3,11 @@ import Hexagon, { hexagonStylingProps } from "../Hexagon/hexagon";
 
 const HexagonGrid = (props) => {
   const {
-    width = 30,
-    borderWidth = 3,
+    width = 50,
+    borderWidth = 5,
     spacing = 2,
     backgroundColor = "#64C7CC",
+    setHexagonStates,
     ...other
   } = props;
 
@@ -108,7 +109,8 @@ const HexagonGrid = (props) => {
             <Hexagon
               key={`${x}:${y}`}
               style={style}
-              {...{ ...hexagonProps, ...type, coord, ...other, mouseDown }}
+              css={hexagonProps}
+              {...{ ...type, coord, ...other, mouseDown, setHexagonStates }}
             />
           );
         })}

--- a/src/HexagonGrid/hexagonGrid.jsx
+++ b/src/HexagonGrid/hexagonGrid.jsx
@@ -7,8 +7,9 @@ const HexagonGrid = (props) => {
     borderWidth = 5,
     spacing = 2,
     backgroundColor = "#64C7CC",
+    hexagonStates,
     setHexagonStates,
-    ...other
+    selected,
   } = props;
 
   const [mouseDown, setMouseDown] = useState(false);
@@ -67,7 +68,7 @@ const HexagonGrid = (props) => {
       );
       const { sizeY } = gridProps;
 
-      Object.entries(props.hexagonStates).forEach((row) => {
+      Object.entries(hexagonStates).forEach((row) => {
         const key = row[0];
         row[1].forEach((coord) => {
           hexagonStartingStates[coord[0] * sizeY + coord[1]] = key;
@@ -84,7 +85,7 @@ const HexagonGrid = (props) => {
     borderWidth,
     backgroundColor,
   });
-  const hexagonStates = hexagonStartingStates(gridProps, props.hexagonStates);
+  const parsedHexagonStates = hexagonStartingStates(gridProps, hexagonStates);
 
   return (
     <div onMouseDown={handleClick(true)} onMouseUp={handleClick(false)}>
@@ -95,14 +96,14 @@ const HexagonGrid = (props) => {
           const transform = coordToPixels(x, y, spacing, width);
 
           // TODO: Use these to centre grid properly
-          const { spaceX, spaceY } = gridProps;
+          // const { spaceX, spaceY } = gridProps;
 
           const style = {
             transform: `translate(${transform.pixelsX}px, ${transform.pixelsY}px)`,
           };
 
           const type = {
-            type: hexagonStates[i],
+            type: parsedHexagonStates[i],
           };
 
           return (
@@ -110,7 +111,14 @@ const HexagonGrid = (props) => {
               key={`${x}:${y}`}
               style={style}
               css={hexagonProps}
-              {...{ ...type, coord, ...other, mouseDown, setHexagonStates }}
+              {...{
+                ...type,
+                coord,
+                selected,
+                mouseDown,
+                hexagonStates,
+                setHexagonStates,
+              }}
             />
           );
         })}

--- a/src/HexagonGrid/hexagonGrid.jsx
+++ b/src/HexagonGrid/hexagonGrid.jsx
@@ -2,94 +2,118 @@ import React, { useState } from "react";
 import Hexagon, { hexagonStylingProps } from "../Hexagon/hexagon";
 
 const HexagonGrid = (props) => {
-    const { width = 50, borderWidth = 5, spacing = 2,
-		backgroundColor = "#64C7CC", ...other } = props;
+  const {
+    width = 30,
+    borderWidth = 3,
+    spacing = 2,
+    backgroundColor = "#64C7CC",
+    ...other
+  } = props;
 
-		const [mouseDown, setMouseDown] = useState(false)
+  const [mouseDown, setMouseDown] = useState(false);
 
-		const handleClick = (state) => {
-			return (event) => {
-				if (event.button === 0) {
-					setMouseDown(state);
-				}
-			}
-		}
+  const handleClick = (state) => {
+    return (event) => {
+      if (event.button === 0) {
+        setMouseDown(state);
+      }
+    };
+  };
 
+  const createGrid = (windowSize, width, spacing, borderWidth) => {
+    if (windowSize.height !== 0 && windowSize.width !== 0) {
+      const horizontalSpacing = width + spacing + 2 * borderWidth;
+      const sizeX = Math.floor((windowSize.width - width) / horizontalSpacing);
+      const spaceX = windowSize.width - (sizeX * horizontalSpacing + width);
 
-    const createGrid = (windowSize, width, spacing, borderWidth) => {
-        if (windowSize.height !== 0 && windowSize.width !== 0) {
-            const horizontalSpacing = width + spacing + 2 * borderWidth;
-            const sizeX = Math.floor((windowSize.width - width) / horizontalSpacing);
-            const spaceX = windowSize.width - (sizeX * horizontalSpacing + width);
-            
-            const verticalSpacing = Math.sqrt(3) / 2 * (spacing + width)
-            const sizeY = Math.floor((windowSize.height - Math.sqrt(3) / 3 * width) / verticalSpacing);
-            const spaceY = windowSize.height - (sizeY * verticalSpacing + Math.sqrt(3) / 3 * width)
-            
-            const coords = [];
-            
-            for (let i = 0; i < sizeX; i++) {
-                for (let j = 0; j < sizeY; j++) {
-                    coords.push([i, j]);
-                }
-            }
-            
-            return { coords, spaceX, spaceY, sizeX, sizeY }
+      const verticalSpacing = (Math.sqrt(3) / 2) * (spacing + width);
+      const sizeY = Math.floor(
+        (windowSize.height - (Math.sqrt(3) / 3) * width) / verticalSpacing
+      );
+      const spaceY =
+        windowSize.height -
+        (sizeY * verticalSpacing + (Math.sqrt(3) / 3) * width);
+
+      const coords = [];
+
+      for (let i = 0; i < sizeX; i++) {
+        for (let j = 0; j < sizeY; j++) {
+          coords.push([i, j]);
         }
+      }
+
+      return { coords, spaceX, spaceY, sizeX, sizeY };
+    }
+  };
+
+  // TODO: To centralise grid of hexagons properly need to make sure this returns exactly
+  // the right spacing, can then update other maths to account for it
+  const coordToPixels = (x, y, spacing, width) => {
+    let pixelsX = (width + spacing) * x;
+    let pixelsY =
+      ((width * Math.sqrt(3)) / 2 + (spacing * Math.sqrt(3)) / 2) * y;
+    if (y % 2 === 1) {
+      pixelsX += width / 2 + spacing / 2;
     }
 
-    // TODO: To centralise grid of hexagons properly need to make sure this returns exactly
-    // the right spacing, can then update other maths to account for it
-    const coordToPixels = (x, y, spacing, width) => {
-        let pixelsX = (width + spacing) * x;
-        let pixelsY = (width * Math.sqrt(3) / 2 + spacing * Math.sqrt(3) / 2) * y;
-        if (y % 2 === 1) {
-            pixelsX += width / 2 + spacing / 2
-        }
-    
-        return { pixelsX, pixelsY }
-		}
-		
-		const hexagonStartingStates = (gridProps, hexagonStates) => {
-			if (gridProps) {
-				const hexagonStartingStates = new Array(gridProps.coords.length).fill('space');
-				const { sizeY } = gridProps;
+    return { pixelsX, pixelsY };
+  };
 
-				Object.entries(props.hexagonStates).forEach((row) => {
-					const key = row[0];
-					row[1].forEach((coord) => {
-						hexagonStartingStates[coord[0] * sizeY + coord[1]] = key;
-					})
-				})
+  const hexagonStartingStates = (gridProps, hexagonStates) => {
+    if (gridProps) {
+      const hexagonStartingStates = new Array(gridProps.coords.length).fill(
+        "space"
+      );
+      const { sizeY } = gridProps;
 
-				return hexagonStartingStates;
-			}
-		}
+      Object.entries(props.hexagonStates).forEach((row) => {
+        const key = row[0];
+        row[1].forEach((coord) => {
+          hexagonStartingStates[coord[0] * sizeY + coord[1]] = key;
+        });
+      });
 
-    const gridProps = createGrid(props.windowSize, width, spacing, borderWidth)
-		const hexagonProps = hexagonStylingProps({ width, borderWidth, backgroundColor });
-		const hexagonStates = hexagonStartingStates(gridProps, props.hexagonStates);
+      return hexagonStartingStates;
+    }
+  };
 
-    return (<div onMouseDown={handleClick(true)} onMouseUp={handleClick(false)}>
-        {gridProps && gridProps.coords.map((coord, i) => {
-            const [x, y] = coord;
+  const gridProps = createGrid(props.windowSize, width, spacing, borderWidth);
+  const hexagonProps = hexagonStylingProps({
+    width,
+    borderWidth,
+    backgroundColor,
+  });
+  const hexagonStates = hexagonStartingStates(gridProps, props.hexagonStates);
 
-            const transform = coordToPixels(x, y, spacing, width);
+  return (
+    <div onMouseDown={handleClick(true)} onMouseUp={handleClick(false)}>
+      {gridProps &&
+        gridProps.coords.map((coord, i) => {
+          const [x, y] = coord;
 
-						// TODO: Use these to centre grid properly
-            const { spaceX, spaceY } = gridProps;
-            
-            const style = {
-                transform: `translate(${transform.pixelsX}px, ${transform.pixelsY}px)`
-						}
+          const transform = coordToPixels(x, y, spacing, width);
 
-						const type = {
-							type: hexagonStates[i]
-						}
-						
-            return <Hexagon key={`${x}:${y}`} style={style} {...{...hexagonProps, ...type, coord, ...other, mouseDown}} />
+          // TODO: Use these to centre grid properly
+          const { spaceX, spaceY } = gridProps;
+
+          const style = {
+            transform: `translate(${transform.pixelsX}px, ${transform.pixelsY}px)`,
+          };
+
+          const type = {
+            type: hexagonStates[i],
+          };
+
+          return (
+            <Hexagon
+              key={`${x}:${y}`}
+              style={style}
+              {...{ ...hexagonProps, ...type, coord, ...other, mouseDown }}
+            />
+          );
         })}
-    </div>)
-}
+    </div>
+  );
+};
 
 export default HexagonGrid;

--- a/src/HexagonGrid/hexagonGrid.jsx
+++ b/src/HexagonGrid/hexagonGrid.jsx
@@ -43,7 +43,7 @@ const HexagonGrid = (props) => {
 			if (gridProps) {
 				const hexagonStartingStates = new Array(gridProps.coords.length).fill('space');
 				const { sizeY } = gridProps;
-		
+				
 				Object.entries(props.hexagonStates).forEach((row) => {
 					const key = row[0];
 					row[1].forEach((coord) => {

--- a/src/HexagonGrid/hexagonGrid.jsx
+++ b/src/HexagonGrid/hexagonGrid.jsx
@@ -6,7 +6,6 @@ const HexagonGrid = (props) => {
     width = 50,
     borderWidth = 5,
     spacing = 2,
-    backgroundColor = "#64C7CC",
     hexagonStates,
     setHexagonStates,
     selected,
@@ -83,7 +82,6 @@ const HexagonGrid = (props) => {
   const hexagonProps = hexagonStylingProps({
     width,
     borderWidth,
-    backgroundColor,
   });
   const parsedHexagonStates = hexagonStartingStates(gridProps, hexagonStates);
 

--- a/src/HexagonGrid/hexagonGrid.jsx
+++ b/src/HexagonGrid/hexagonGrid.jsx
@@ -65,6 +65,7 @@ const HexagonGrid = (props) => {
 
             const transform = coordToPixels(x, y, spacing, width);
 
+						// TODO: Use these to centre grid properly
             const { spaceX, spaceY } = gridProps;
             
             const style = {

--- a/src/HexagonGrid/hexagonGrid.jsx
+++ b/src/HexagonGrid/hexagonGrid.jsx
@@ -1,10 +1,21 @@
-import React from "react";
+import React, { useState } from "react";
 import Hexagon, { hexagonStylingProps } from "../Hexagon/hexagon";
 
 const HexagonGrid = (props) => {
-    const { width = 50, borderWidth = 5, spacing = 5,
+    const { width = 50, borderWidth = 5, spacing = 2,
 		backgroundColor = "#64C7CC", ...other } = props;
-		
+
+		const [mouseDown, setMouseDown] = useState(false)
+
+		const handleClick = (state) => {
+			return (event) => {
+				if (event.button === 0) {
+					setMouseDown(state);
+				}
+			}
+		}
+
+
     const createGrid = (windowSize, width, spacing, borderWidth) => {
         if (windowSize.height !== 0 && windowSize.width !== 0) {
             const horizontalSpacing = width + spacing + 2 * borderWidth;
@@ -43,7 +54,7 @@ const HexagonGrid = (props) => {
 			if (gridProps) {
 				const hexagonStartingStates = new Array(gridProps.coords.length).fill('space');
 				const { sizeY } = gridProps;
-				
+
 				Object.entries(props.hexagonStates).forEach((row) => {
 					const key = row[0];
 					row[1].forEach((coord) => {
@@ -59,7 +70,7 @@ const HexagonGrid = (props) => {
 		const hexagonProps = hexagonStylingProps({ width, borderWidth, backgroundColor });
 		const hexagonStates = hexagonStartingStates(gridProps, props.hexagonStates);
 
-    return (<div>
+    return (<div onMouseDown={handleClick(true)} onMouseUp={handleClick(false)}>
         {gridProps && gridProps.coords.map((coord, i) => {
             const [x, y] = coord;
 
@@ -76,7 +87,7 @@ const HexagonGrid = (props) => {
 							type: hexagonStates[i]
 						}
 						
-            return <Hexagon key={`${x}:${y}`} style={style} {...{...hexagonProps, ...type, coord, ...other}} />
+            return <Hexagon key={`${x}:${y}`} style={style} {...{...hexagonProps, ...type, coord, ...other, mouseDown}} />
         })}
     </div>)
 }

--- a/src/Toolbar/Context.js
+++ b/src/Toolbar/Context.js
@@ -1,0 +1,3 @@
+import React from "react";
+
+export const StateContext = React.createContext('wall');

--- a/src/Toolbar/toolbar.jsx
+++ b/src/Toolbar/toolbar.jsx
@@ -34,6 +34,7 @@ const Toolbar = () => {
       [8, 5],
     ],
   });
+
   const [selected, setSelected] = useState("wall");
 
   return (

--- a/src/Toolbar/toolbar.jsx
+++ b/src/Toolbar/toolbar.jsx
@@ -76,6 +76,9 @@ const Toolbar = () => {
               <Menu.Item key="3" onClick={() => setSelected("wall")}>
                 Wall
               </Menu.Item>
+              <Menu.Item key="4" onClick={() => setSelected("space")}>
+                Space
+              </Menu.Item>
             </SubMenu>
             <SubMenu
               key="sub3"
@@ -91,7 +94,11 @@ const Toolbar = () => {
         </Sider>
         <Canvas
           Component={HexagonGrid}
-          {...{ selected, hexagonStates, setHexagonStates }}
+          {...{
+            selected,
+            hexagonStates,
+            setHexagonStates,
+          }}
         />
       </Layout>
     </Layout>

--- a/src/Toolbar/toolbar.jsx
+++ b/src/Toolbar/toolbar.jsx
@@ -15,9 +15,9 @@ const { Sider } = Layout;
 
 const Toolbar = () => {
 	const [hexagonStates, setHexagonStates] = useState({
-		start: [],
-		goal: [],
-		wall: [],
+		goal: [[7, 3]],
+		start: [[4, 5]],
+		wall: [[8, 2], [5, 4], [6, 7], [5, 5], [6, 4], [7, 4], [6, 5], [7, 6], [4, 3], [4, 2], [3, 2], [7, 7], [8, 6], [8, 5]]
 	})
 	const [selected, setSelected] = useState('wall')
 

--- a/src/Toolbar/toolbar.jsx
+++ b/src/Toolbar/toolbar.jsx
@@ -14,33 +14,67 @@ const { SubMenu } = Menu;
 const { Sider } = Layout;
 
 const Toolbar = () => {
-	const [hexagonStates, setHexagonStates] = useState({
-		goal: [[7, 3]],
-		start: [[4, 5]],
-		wall: [[8, 2], [5, 4], [6, 7], [5, 5], [6, 4], [7, 4], [6, 5], [7, 6], [4, 3], [4, 2], [3, 2], [7, 7], [8, 6], [8, 5]]
-	})
-	const [selected, setSelected] = useState('wall')
+  const [hexagonStates, setHexagonStates] = useState({
+    goal: [[7, 3]],
+    start: [[4, 5]],
+    wall: [
+      [8, 2],
+      [5, 4],
+      [6, 7],
+      [5, 5],
+      [6, 4],
+      [7, 4],
+      [6, 5],
+      [7, 6],
+      [4, 3],
+      [4, 2],
+      [3, 2],
+      [7, 7],
+      [8, 6],
+      [8, 5],
+    ],
+  });
+  const [selected, setSelected] = useState("wall");
 
   return (
     <Layout>
       <Layout>
         <Sider width={200} className="site-layout-background">
-          <Menu
-						mode="inline"
-            style={{ height: "100vh" }}
-          >
-            <SubMenu key="sub1" icon={<UserOutlined />} title="Required" style={{
-							color: (hexagonStates.start.length === 0 || hexagonStates.goal.length === 0) && "red"
-						}}>
-              <Menu.Item key="1" onClick={() => setSelected('start')} style={{
-								color: hexagonStates.start.length === 0 && "red"
-							}}>Start</Menu.Item>
-              <Menu.Item key="2" onClick={() => setSelected('goal')} style={{
-								color: hexagonStates.goal.length === 0 && "red"
-							}}>Goal</Menu.Item>
+          <Menu mode="inline" style={{ height: "100vh" }}>
+            <SubMenu
+              key="sub1"
+              icon={<UserOutlined />}
+              title="Required"
+              style={{
+                color:
+                  (hexagonStates.start.length === 0 ||
+                    hexagonStates.goal.length === 0) &&
+                  "red",
+              }}
+            >
+              <Menu.Item
+                key="1"
+                onClick={() => setSelected("start")}
+                style={{
+                  color: hexagonStates.start.length === 0 && "red",
+                }}
+              >
+                Start
+              </Menu.Item>
+              <Menu.Item
+                key="2"
+                onClick={() => setSelected("goal")}
+                style={{
+                  color: hexagonStates.goal.length === 0 && "red",
+                }}
+              >
+                Goal
+              </Menu.Item>
             </SubMenu>
-            <SubMenu key="sub2" icon={<LaptopOutlined />} title="Optional" >
-              <Menu.Item key="3" onClick={() => setSelected('wall')}>Wall</Menu.Item>
+            <SubMenu key="sub2" icon={<LaptopOutlined />} title="Optional">
+              <Menu.Item key="3" onClick={() => setSelected("wall")}>
+                Wall
+              </Menu.Item>
             </SubMenu>
             <SubMenu
               key="sub3"
@@ -54,10 +88,13 @@ const Toolbar = () => {
             </SubMenu>
           </Menu>
         </Sider>
-            <Canvas Component={HexagonGrid} {...{selected, hexagonStates, setHexagonStates}} />
+        <Canvas
+          Component={HexagonGrid}
+          {...{ selected, hexagonStates, setHexagonStates }}
+        />
       </Layout>
     </Layout>
   );
-}
+};
 
 export default Toolbar;

--- a/src/Utilities/utilities.js
+++ b/src/Utilities/utilities.js
@@ -1,0 +1,6 @@
+export function arrayEquals(a, b) {
+  return Array.isArray(a) &&
+    Array.isArray(b) &&
+    a.length === b.length &&
+    a.every((val, index) => val === b[index]);
+};


### PR DESCRIPTION
Only hexagons that need to re-render and now re-rendered, using a class based component and making use of the shouldComponentUpdate hook. In this method each hexagon stores it's individual type (to allow for this case by case rendering method), but the overall state of the grid is stored further up. This can then be sent to the path finding algorithms directly.