### PR TITLE
Hexagon grid refactor

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@types/node": "^14.14.7",
     "@types/react": "^16.9.56",
     "@types/react-dom": "^16.9.9",
+    "@types/styled-components": "^5.1.4",
     "antd": "^4.7.2",
     "react": "^17.0.1",
     "react-dom": "^17.0.0",

--- a/src/Algorithms/base.js
+++ b/src/Algorithms/base.js
@@ -1,5 +1,10 @@
 import { twoDToOneDCoord } from "../Utilities/utilities"
 
+export const router = (algorithm, hexagonStates, sizeX, sizeY) => {
+  console.log('router called');
+  console.log(algorithm, hexagonStates, sizeX, sizeY);
+}
+
 export const neighbours = (coord, sizeX, sizeY) => {
   const [x, y] = coord;
 

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,9 +1,0 @@
-import React from 'react';
-import { render } from '@testing-library/react';
-import App from './App';
-
-test('renders learn react link', () => {
-  const { getByText } = render(<App />);
-  const linkElement = getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
-});

--- a/src/Canvas/canvas.tsx
+++ b/src/Canvas/canvas.tsx
@@ -1,13 +1,25 @@
-import React, { useRef, useEffect, useState } from "react";
+import React, { createRef } from "react";
+import { Setter } from "../types/dtypes";
 
 type CanvasProps = {
   Component: Function;
   [key: string]: any;
+  setGridSize: Setter;
 };
 
 export type WindowSize = {
   height: number;
   width: number;
+};
+
+type Ref = React.RefObject<HTMLDivElement>;
+
+type CanvasState = {
+  ref: Ref;
+  windowSize: {
+    height: number;
+    width: number;
+  };
 };
 
 /**
@@ -16,34 +28,58 @@ export type WindowSize = {
  * @param {object} props the child component, and any props to pass to the child
  * component
  */
-const Canvas = (props: CanvasProps): JSX.Element => {
-  const { Component, ...other } = props;
+class Canvas extends React.Component<CanvasProps, CanvasState> {
+  constructor(props: CanvasProps) {
+    super(props);
 
-  const ref = useRef<HTMLDivElement>(null);
-  const [windowSize, setWindowSize] = useState<WindowSize>({
-    height: 0,
-    width: 0,
-  });
+    this.state = {
+      ref: createRef(),
+      windowSize: {
+        height: 0,
+        width: 0,
+      },
+    };
+  }
 
-  useEffect(() => {
-    setWindowSize({
-      height: ref?.current?.offsetHeight ?? 0,
-      width: ref?.current?.offsetWidth ?? 0,
+  componentDidMount() {
+    const ref: Ref = this.state.ref;
+    this.setState({
+      windowSize: {
+        height: ref.current?.offsetHeight ?? 0,
+        width: ref.current?.offsetWidth ?? 0,
+      },
     });
-  }, []);
+  }
 
-  const canvasStyle = {
-    overflow: "hidden",
-    height: "100vh",
-    width: "100vw",
-    backgroundColor: "#dddddd",
-  };
+  shouldComponentUpdate(nextProps: CanvasProps, nextState: CanvasState) {
+    const currentWindow = this.state.windowSize;
+    const nextWindow = nextState.windowSize;
+    return (
+      currentWindow.height !== nextWindow.height ||
+      currentWindow.width !== nextWindow.width
+    );
+  }
 
-  return (
-    <div ref={ref} style={canvasStyle}>
-      <Component {...{ windowSize, ...other }} />
-    </div>
-  );
-};
+  render() {
+    const canvasStyle = {
+      overflow: "hidden",
+      height: "100vh",
+      width: "100vw",
+      backgroundColor: "#dddddd",
+    };
+
+    return (
+      <div ref={this.state.ref} style={canvasStyle}>
+        <this.props.Component
+          {...{
+            windowSize: this.state.windowSize,
+            siderWidth: this.props.siderWidth,
+            setGridSize: this.props.setGridSize,
+          }}
+        />
+      </div>
+    );
+  }
+}
 
 export default Canvas;

--- a/src/Hexagon/hexagon.tsx
+++ b/src/Hexagon/hexagon.tsx
@@ -1,7 +1,22 @@
 import React from "react";
 import styled from "styled-components";
+import { Coord, HexagonStates, HexagonTypes, Setter } from "../types/dtypes";
 import { arrayEquals } from "../Utilities/utilities";
 
+export interface FixedHexagonStylingProps {
+  middleWidth: number;
+  middleHeight: number;
+  topBotDiameter: number;
+  margin: number;
+  topBotBorderWidth: number;
+  middleBorderWidth: number;
+  left: number;
+  topBot: number;
+}
+
+export interface StyledHexagonProps extends FixedHexagonStylingProps {
+  backgroundColor: string;
+}
 // TODO: Cannot find a way to set multiple properties to the same value,
 // would be useful for setting border-left and border-right at the same time,
 // have tried using , like with &:before &:after but that doesn't work
@@ -10,36 +25,42 @@ import { arrayEquals } from "../Utilities/utilities";
  */
 const StyledHexagon = styled.div`
   position: absolute;
-  width: ${(props) => `${props.middleWidth}px`};
-  height: ${(props) => `${props.middleHeight}px`};
-  background-color: ${(props) => props.backgroundColor};
-  border-left: ${(props) => borderStyle(props.middleBorderWidth)};
-  border-right: ${(props) => borderStyle(props.middleBorderWidth)};
+  width: ${(props: StyledHexagonProps) => `${props.middleWidth}px`};
+  height: ${(props: StyledHexagonProps) => `${props.middleHeight}px`};
+  background-color: ${(props: StyledHexagonProps) => props.backgroundColor};
+  border-left: ${(props: StyledHexagonProps) =>
+    borderStyle(props.middleBorderWidth)};
+  border-right: ${(props: StyledHexagonProps) =>
+    borderStyle(props.middleBorderWidth)};
   &:before,
   &:after {
     content: "";
     position: absolute;
     z-index: 1;
-    width: ${(props) => `${props.topBotDiameter}px`};
-    height: ${(props) => `${props.topBotDiameter}px`};
+    width: ${(props: StyledHexagonProps) => `${props.topBotDiameter}px`};
+    height: ${(props: StyledHexagonProps) => `${props.topBotDiameter}px`};
     transform: scaleY(0.5774) rotate(-45deg);
     background-color: inherit;
-    left: ${(props) => `${props.left}px`};
+    left: ${(props: StyledHexagonProps) => `${props.left}px`};
   }
   &:before {
-    top: ${(props) => `${props.topBot}px`};
-    border-top: ${(props) => borderStyle(props.topBotBorderWidth)};
-    border-right: ${(props) => borderStyle(props.topBotBorderWidth)};
+    top: ${(props: StyledHexagonProps) => `${props.topBot}px`};
+    border-top: ${(props: StyledHexagonProps) =>
+      borderStyle(props.topBotBorderWidth)};
+    border-right: ${(props: StyledHexagonProps) =>
+      borderStyle(props.topBotBorderWidth)};
   }
   &:after {
-    bottom: ${(props) => `${props.topBot}px`};
-    border-bottom: ${(props) => borderStyle(props.topBotBorderWidth)};
-    border-left: ${(props) => borderStyle(props.topBotBorderWidth)};
+    bottom: ${(props: StyledHexagonProps) => `${props.topBot}px`};
+    border-bottom: ${(props: StyledHexagonProps) =>
+      borderStyle(props.topBotBorderWidth)};
+    border-left: ${(props: StyledHexagonProps) =>
+      borderStyle(props.topBotBorderWidth)};
   }
 `;
 
 // Used in the CSS hexagon above
-const borderStyle = (borderWidth) => `solid ${borderWidth}px #333333`;
+const borderStyle = (borderWidth: number) => `solid ${borderWidth}px #333333`;
 
 /**
  * Returns an object containing all parameters that physically specify a hexagon
@@ -48,7 +69,10 @@ const borderStyle = (borderWidth) => `solid ${borderWidth}px #333333`;
  * @param {float} borderWidth: the width of the border, from the outer of the hexagon
  * to the outer of the border
  */
-export const hexagonStylingProps = ({ width, borderWidth }) => {
+export const hexagonStylingProps = ({
+  width,
+  borderWidth,
+}: any): FixedHexagonStylingProps => {
   return {
     middleWidth: width,
     middleHeight: (Math.sqrt(3) / 3) * width,
@@ -65,7 +89,7 @@ export const hexagonStylingProps = ({ width, borderWidth }) => {
  * Converts the type of a hexagon into the colour it's background should be
  * @param type: the state of the hexagon, currently 'space', 'wall', 'goal', or 'start'
  */
-const typeToStyling = (type) => {
+const typeToStyling = (type: string) => {
   let backgroundColor = "#64C7CC";
   switch (type) {
     case "space":
@@ -85,6 +109,17 @@ const typeToStyling = (type) => {
   return backgroundColor;
 };
 
+export interface HexagonProps {
+  type: HexagonTypes;
+  selected: HexagonTypes;
+  mouseDown: boolean;
+  css: any;
+  style: any;
+  setHexagonStates: Setter;
+  hexagonStates: HexagonStates;
+  coord: Coord;
+}
+
 /**
  * A general hexagon class, used to build up the hexagon grid.
  * The logic behind it is as follows:
@@ -96,7 +131,7 @@ const typeToStyling = (type) => {
  * - When each hexagon receives it's new type (according to the grid store), it updates only if it's current type
  * doesn't match the new one
  */
-class Hexagon extends React.Component {
+class Hexagon extends React.Component<HexagonProps> {
   /**
    * A mapping from state types to whether that state is limited in it's numbers or not
    * there can only be one goal and one start point, but many walls
@@ -115,7 +150,7 @@ class Hexagon extends React.Component {
    * been passed in
    * @param {object} nextProps: the new properties passed into the hexagon
    */
-  shouldComponentUpdate(nextProps) {
+  shouldComponentUpdate(nextProps: HexagonProps) {
     return nextProps.type !== this.props.type;
   }
 
@@ -126,7 +161,7 @@ class Hexagon extends React.Component {
    * @param {object} newHexagonStates: a copy of the hexagonStates object to modify
    * @returns newHexagonStates: with the old state of this hexagon removed
    */
-  removeOldState(oldType, newHexagonStates) {
+  removeOldState(oldType: HexagonTypes, newHexagonStates: HexagonStates) {
     if (oldType !== "space") {
       if (this.limitedState[oldType]) {
         newHexagonStates[oldType] = [];
@@ -146,7 +181,7 @@ class Hexagon extends React.Component {
    * @param {object} newHexagonStates: a copy of the hexagonStates object to modify
    * @returns newHexagonStates: with the new state of this hexagon added to it
    */
-  addNewState(newType, newHexagonStates) {
+  addNewState(newType: HexagonTypes, newHexagonStates: HexagonStates) {
     if (newType !== "space") {
       if (this.limitedState[newType]) {
         newHexagonStates[newType] = [this.props.coord];
@@ -163,7 +198,10 @@ class Hexagon extends React.Component {
    * @param {object} event: event object from e.g. a click
    * @param {string} oldType: 'space' | 'wall' | 'goal' | 'start'
    */
-  handleChange = (event, oldType) => {
+  handleChange = (
+    event: React.MouseEvent<HTMLElement>,
+    oldType: HexagonTypes
+  ) => {
     if (event.button === 0) {
       const newType = this.props.selected;
 
@@ -183,24 +221,33 @@ class Hexagon extends React.Component {
    * @param {object} event: onMouseOver event
    * @param {string} oldType: 'space' | 'wall' | 'goal' | 'start'
    */
-  handleHover = (event, oldType) => {
+  handleHover = (
+    event: React.MouseEvent<HTMLElement>,
+    oldType: HexagonTypes
+  ) => {
     if (this.props.mouseDown) {
       this.handleChange(event, oldType);
     }
   };
 
   render() {
-    const type = this.props.type;
+    const { type, css, style } = this.props as HexagonProps;
     const backgroundColor = typeToStyling(type);
 
     // NOTE: Type is stored in the functions instead of on this.state
     return (
       <StyledHexagon
-        {...{ ...this.props.css, backgroundColor }}
-        style={this.props.style}
-        onClick={(event) => this.handleChange(event, type)}
-        onMouseOver={(event) => this.handleHover(event, type)}
-        onMouseDown={(event) => this.handleChange(event, type)}
+        {...{ ...css, backgroundColor }}
+        style={style}
+        onClick={(event: React.MouseEvent<HTMLElement>) =>
+          this.handleChange(event, type)
+        }
+        onMouseOver={(event: React.MouseEvent<HTMLElement>) =>
+          this.handleHover(event, type)
+        }
+        onMouseDown={(event: React.MouseEvent<HTMLElement>) =>
+          this.handleChange(event, type)
+        }
       />
     );
   }

--- a/src/HexagonGrid/hexagonGridManager.tsx
+++ b/src/HexagonGrid/hexagonGridManager.tsx
@@ -1,0 +1,127 @@
+import React from "react";
+import { WindowSize } from "../Canvas/canvas";
+import HexagonGrid from "./hexagonGrid";
+import { Coord, Coords, Setter } from "../types/dtypes";
+import { hexagonStylingProps } from "../Hexagon/hexagon";
+import {
+  HexagonGridPropertiesContext,
+  GridPropertiesContext,
+} from "../Toolbar/Context";
+
+type HexagonGridManagerProps = {
+  width?: number;
+  borderWidth?: number;
+  spacing?: number;
+  siderWidth: number;
+  windowSize: WindowSize;
+  setGridSize: Setter;
+};
+
+export type CreateGridReturn = {
+  coords: Coords;
+  offsetX: number;
+  offsetY: number;
+  sizeX: number;
+  sizeY: number;
+};
+
+/**
+ * Wrapper component to manage overarching state for the hexagon grid, such
+ * that each change of the HexagonStates don't cause a recalculation of
+ * static properties
+ */
+const HexagonGridManager = (props: HexagonGridManagerProps) => {
+  const {
+    width = 50,
+    borderWidth = 5,
+    spacing = 5,
+    siderWidth,
+    windowSize,
+    setGridSize,
+  } = props;
+
+  const horizontalSpacing = width + spacing;
+  const verticalSpacing = (Math.sqrt(3) / 2) * width + spacing / 2;
+
+  /**
+   * Given the size of the window to display the grid, calculates the list of possible
+   * coordinates, the available border width for the grid, and the dimensions of the grid
+   * @param {number} windowSize
+   */
+  const createGrid = (
+    windowSize: WindowSize,
+    siderWidth: number
+  ): CreateGridReturn | undefined => {
+    if (windowSize.height !== 0 && windowSize.width !== 0) {
+      const sizeX = Math.floor(
+        (windowSize.width - siderWidth - horizontalSpacing / 2) /
+          horizontalSpacing
+      );
+
+      const sizeY = Math.floor(
+        (windowSize.height - (Math.sqrt(3) / 3) * width) / verticalSpacing
+      );
+
+      const offsetX =
+        (windowSize.width - siderWidth - (sizeX + 0.5) * horizontalSpacing) / 2;
+      const offsetY = (windowSize.height - (sizeY + 0.5) * verticalSpacing) / 2;
+
+      const coords: Coords = [];
+
+      for (let i = 0; i < sizeX; i++) {
+        for (let j = 0; j < sizeY; j++) {
+          const coord: Coord = [i, j];
+          coords.push(coord);
+        }
+      }
+
+      return { coords, offsetX, offsetY, sizeX, sizeY };
+    }
+  };
+
+  /**
+   * Converts a coordinate into a pixel coordinate
+   * @param {number} x
+   * @param {number} y
+   */
+  const coordToPixels = (x: number, y: number): Coord => {
+    let pixelsX = horizontalSpacing * x;
+    const pixelsY = verticalSpacing * y + (Math.sqrt(3) / 6) * width;
+    if (y % 2 === 1) {
+      pixelsX += horizontalSpacing / 2;
+    }
+
+    return [pixelsX, pixelsY];
+  };
+
+  const gridProps = createGrid(windowSize, siderWidth);
+
+  if (gridProps) {
+    setGridSize({
+      x: gridProps?.sizeX,
+      y: gridProps?.sizeY,
+    });
+    // Calculate the styling props once and then use it for all hexagons
+    const hexagonCssProps = hexagonStylingProps({
+      width,
+      borderWidth,
+    });
+
+    const pixelsCoords: Coords = gridProps?.coords.map((coord: Coord) =>
+      coordToPixels(...coord)
+    );
+    return (
+      <HexagonGridPropertiesContext.Consumer>
+        {(value: GridPropertiesContext) => (
+          <HexagonGrid
+            {...{ ...value, hexagonCssProps, pixelsCoords, gridProps }}
+          />
+        )}
+      </HexagonGridPropertiesContext.Consumer>
+    );
+  } else {
+    return null;
+  }
+};
+
+export default HexagonGridManager;

--- a/src/Toolbar/Context.ts
+++ b/src/Toolbar/Context.ts
@@ -1,4 +1,20 @@
 import React from "react";
-import { HexagonTypes } from '../types/dtypes';
+import { HexagonStates, Setter, HexagonTypes } from '../types/dtypes';
 
-export const StateContext = React.createContext<HexagonTypes>('wall');
+export type GridPropertiesContext = {
+  hexagonStates: HexagonStates;
+  setHexagonStates: Setter;
+  selected: HexagonTypes;
+};
+
+export const HexagonGridPropertiesContext = React.createContext<
+  GridPropertiesContext
+>({
+  hexagonStates: {
+    goal: [],
+    start: [],
+    wall: [],
+  } as HexagonStates,
+  setHexagonStates: (value: HexagonStates): void => {},
+  selected: "wall",
+});

--- a/src/Toolbar/toolbar.tsx
+++ b/src/Toolbar/toolbar.tsx
@@ -8,9 +8,10 @@ import {
 import "./toolbar.css";
 import "antd/dist/antd.css";
 import Canvas from "../Canvas/canvas";
-import HexagonGrid from "../HexagonGrid/hexagonGrid";
 import { router } from "../Algorithms/base";
 import { HexagonTypes, HexagonStates } from "../types/dtypes";
+import HexagonGridManager from "../HexagonGrid/hexagonGridManager";
+import { HexagonGridPropertiesContext } from "./Context";
 
 const { SubMenu } = Menu;
 const { Sider } = Layout;
@@ -104,10 +105,12 @@ const Toolbar = () => {
                 color: algorithm.length === 0 ? "red" : undefined,
               }}
             >
-              <Menu.Item key="9">option9</Menu.Item>
-              <Menu.Item key="10">option10</Menu.Item>
-              <Menu.Item key="11">option11</Menu.Item>
-              <Menu.Item key="12">option12</Menu.Item>
+              <Menu.Item key="9" onClick={() => setAlgorithm("dijkstra")}>
+                Dijkstra
+              </Menu.Item>
+              <Menu.Item key="10" onClick={() => setAlgorithm("greedy")}>
+                Greedy
+              </Menu.Item>
             </SubMenu>
             <div
               style={{
@@ -138,15 +141,17 @@ const Toolbar = () => {
             </div>
           </Menu>
         </Sider>
-        <Canvas
-          Component={HexagonGrid}
-          {...{
-            selected,
-            hexagonStates,
-            setHexagonStates,
-            siderWidth,
-          }}
-        />
+        <HexagonGridPropertiesContext.Provider
+          value={{ hexagonStates, setHexagonStates, selected }}
+        >
+          <Canvas
+            Component={HexagonGridManager}
+            {...{
+              siderWidth,
+              setGridSize,
+            }}
+          />
+        </HexagonGridPropertiesContext.Provider>
       </Layout>
     </Layout>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1628,6 +1628,14 @@
     "@types/minimatch" "*"
     "@types/node" "*"
 
+"@types/hoist-non-react-statics@*":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
+  integrity sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==
+  dependencies:
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
+
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz#42995b446db9a48a11a07ec083499a860e9138ff"
@@ -1717,6 +1725,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-native@*":
+  version "0.63.35"
+  resolved "https://registry.yarnpkg.com/@types/react-native/-/react-native-0.63.35.tgz#c9d6c3c0461b1aa0dff89c6b53ef509461a19183"
+  integrity sha512-2uyPZoHtoUVsVO55HdrRCpgwwG2zVHLttTaR9f/BThoBAQngNWuZQ0eMGmfgRHBKXmi3TmtWjbWPxohkITLlkw==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react@*":
   version "16.9.53"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.53.tgz#40cd4f8b8d6b9528aedd1fff8fcffe7a112a3d23"
@@ -1737,6 +1752,16 @@
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
   integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
+
+"@types/styled-components@^5.1.4":
+  version "5.1.4"
+  resolved "https://registry.yarnpkg.com/@types/styled-components/-/styled-components-5.1.4.tgz#11f167dbde268635c66adc89b5a5db2e69d75384"
+  integrity sha512-78f5Zuy0v/LTQNOYfpH+CINHpchzMMmAt9amY2YNtSgsk1TmlKm8L2Wijss/mtTrsUAVTm2CdGB8VOM65vA8xg==
+  dependencies:
+    "@types/hoist-non-react-statics" "*"
+    "@types/react" "*"
+    "@types/react-native" "*"
+    csstype "^3.0.2"
 
 "@types/testing-library__dom@*":
   version "7.5.0"
@@ -5278,7 +5303,7 @@ hmac-drbg@^1.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.3.2:
+hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==


### PR DESCRIPTION
Converting the hexagon component to a typescript component, and refactoring multiple components into class components. This was done to reduce re-rendering of child components of the toolbar (where hooks change frequently), such that only the hexagon grid needs to re-render.