### PR TITLE
mouseDown refactor

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,8 +1,25 @@
-import React from "react";
+import React, { useState } from "react";
 import Toolbar from "./Toolbar/toolbar";
+import { MouseDownContext } from "./Toolbar/Context";
 
-function App() {
-  return <Toolbar />;
+const App = () => {
+  const [mouseDown, setMouseDown] = useState(false);
+
+  const handleMouseDown = (state) => {
+    return (event) => {
+      if (event.button === 0) {
+        setMouseDown(state);
+      }
+    };
+  };
+
+  return (
+    <div onMouseDown={handleMouseDown(true)} onMouseUp={handleMouseDown(false)}>
+      <MouseDownContext.Provider value={mouseDown}>
+        <Toolbar />
+      </MouseDownContext.Provider>
+    </div>
+  );
 }
 
 export default App;

--- a/src/HexagonGrid/hexagonGrid.tsx
+++ b/src/HexagonGrid/hexagonGrid.tsx
@@ -9,6 +9,7 @@ import {
 import { CreateGridReturn } from "./hexagonGridManager";
 import { twoDToOneDCoord } from "../Utilities/utilities";
 import Hexagon, { FixedHexagonStylingProps } from "../Hexagon/hexagon";
+import { MouseDownContext } from "../Toolbar/Context";
 
 type HexagonGridProps = {
   hexagonStates: HexagonStates;
@@ -33,17 +34,6 @@ const HexagonGrid = (props: HexagonGridProps) => {
     gridProps,
     hexagonCssProps,
   } = props;
-
-  const [mouseDown, setMouseDown] = useState(false);
-
-  const handleMouseDown = (state: boolean): Setter => {
-    return (event: React.MouseEvent<HTMLDivElement>) => {
-      if (event.button === 0) {
-        setMouseDown(state);
-      }
-    };
-  };
-
   /**
    * Maps a grid specification of the form
    * {
@@ -77,40 +67,44 @@ const HexagonGrid = (props: HexagonGridProps) => {
   const parsedHexagonStates = hexagonStartingStates(gridProps, hexagonStates);
 
   return (
-    <div onMouseDown={handleMouseDown(true)} onMouseUp={handleMouseDown(false)}>
-      {gridProps &&
-        parsedHexagonStates &&
-        gridProps.coords.map((coord, i) => {
-          const [x, y] = coord;
+    <MouseDownContext.Consumer>
+      {(value) => (
+        <div>
+          {gridProps &&
+            parsedHexagonStates &&
+            gridProps.coords.map((coord, i) => {
+              const [x, y] = coord;
 
-          const transform = pixelsCoords[i];
+              const transform = pixelsCoords[i];
 
-          const { offsetX, offsetY } = gridProps;
+              const { offsetX, offsetY } = gridProps;
 
-          // maps hexagons to correct coordinate and centre the entire grid
-          const style = {
-            transform: `translate(${transform[0] + offsetX}px, ${
-              transform[1] + offsetY
-            }px)`,
-          };
+              // maps hexagons to correct coordinate and centre the entire grid
+              const style = {
+                transform: `translate(${transform[0] + offsetX}px, ${
+                  transform[1] + offsetY
+                }px)`,
+              };
 
-          return (
-            <Hexagon
-              key={`${x}:${y}`}
-              style={style}
-              css={hexagonCssProps}
-              {...{
-                type: parsedHexagonStates[i],
-                coord,
-                selected,
-                mouseDown,
-                hexagonStates,
-                setHexagonStates,
-              }}
-            />
-          );
-        })}
-    </div>
+              return (
+                <Hexagon
+                  key={`${x}:${y}`}
+                  style={style}
+                  css={hexagonCssProps}
+                  {...{
+                    type: parsedHexagonStates[i],
+                    coord,
+                    selected,
+                    mouseDown: value,
+                    hexagonStates,
+                    setHexagonStates,
+                  }}
+                />
+              );
+            })}
+        </div>
+      )}
+    </MouseDownContext.Consumer>
   );
 };
 

--- a/src/HexagonGrid/hexagonGridManager.tsx
+++ b/src/HexagonGrid/hexagonGridManager.tsx
@@ -112,11 +112,18 @@ const HexagonGridManager = (props: HexagonGridManagerProps) => {
     );
     return (
       <HexagonGridPropertiesContext.Consumer>
-        {(value: GridPropertiesContext) => (
-          <HexagonGrid
-            {...{ ...value, hexagonCssProps, pixelsCoords, gridProps }}
-          />
-        )}
+        {(value: GridPropertiesContext) => {
+          return (
+            <HexagonGrid
+              {...{
+                ...value,
+                hexagonCssProps,
+                pixelsCoords,
+                gridProps,
+              }}
+            />
+          );
+        }}
       </HexagonGridPropertiesContext.Consumer>
     );
   } else {

--- a/src/Toolbar/Context.ts
+++ b/src/Toolbar/Context.ts
@@ -18,3 +18,5 @@ export const HexagonGridPropertiesContext = React.createContext<
   setHexagonStates: (value: HexagonStates): void => {},
   selected: "wall",
 });
+
+export const MouseDownContext = React.createContext<boolean>(false);


### PR DESCRIPTION
#8 mouseDown prop is now provided via context and is wrapped by the entire app, this means when letting go of mouseDown outside the hexagonGrid is still detected.